### PR TITLE
[#16] 로그인 페이지 리팩 1) ts 적용 및 api 분리

### DIFF
--- a/src/Page/LoginPage.tsx
+++ b/src/Page/LoginPage.tsx
@@ -1,48 +1,43 @@
-import {
-  Alert,
-  Avatar,
-  Box,
-  Container,
-  Grid,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Alert, Avatar, Box, Container, Grid, TextField, Typography } from "@mui/material";
 import LoginIcon from "@mui/icons-material/Login";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Divider } from "antd";
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
-import "../firebase";
+import { login } from "../api/auth/index";
+import { TLoginForm } from "../model";
 
 function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const login = useCallback(async (email, password) => {
+  const handleLogin = useCallback(async (loginForm: TLoginForm) => {
+    // 화살표 함수 앞의 괄호를 수정
     setLoading(true);
-    const auth = getAuth();
-    await signInWithEmailAndPassword(auth, email, password).catch((error) => {
-      const errorMessage = error.message;
-      setError(errorMessage);
-    });
+    const response = await login(loginForm);
+    if (!response.success) {
+      setError(response.error || "로그인 실패");
+    }
     setLoading(false);
   }, []);
 
   const handleSubmit = useCallback(
-    (event) => {
+    (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      const data = new FormData(event.currentTarget);
-      const email = data.get("email");
-      const password = data.get("password");
+      const form = event.currentTarget;
 
-      if (!email || !password) {
+      const loginForm = {
+        email: form.email.value,
+        password: form.password.value,
+      };
+
+      if (!loginForm.email || !loginForm.password) {
         setError("모든 항목을 입력해주세요");
         return;
       }
-      login(email, password);
+      login(loginForm);
     },
-    [login]
+    [login],
   );
 
   useEffect(() => {
@@ -62,28 +57,10 @@ function LoginPage() {
           <Typography component="h1" variant="h5" color="black">
             로그인
           </Typography>
-          <Box
-            component="form"
-            noValidate
-            onSubmit={handleSubmit}
-            sx={{ mt: 1 }}>
+          <Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 1 }}>
             {/* 관리자 직원에 따라 추가정보 요구 */}
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              label="이메일"
-              name="email"
-              autoComplete="off"
-            />
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              label="비밀번호"
-              name="password"
-              type="password"
-            />
+            <TextField margin="normal" required fullWidth label="이메일" name="email" autoComplete="off" />
+            <TextField margin="normal" required fullWidth label="비밀번호" name="password" type="password" />
             {/* 에러시 오류 표시 */}
             {error ? (
               <Alert sx={{ mt: 3 }} severity="error">
@@ -102,9 +79,7 @@ function LoginPage() {
             </LoadingButton>
             <Grid container justifyContent="flex-end">
               <Grid item>
-                <Link
-                  to="/signup"
-                  style={{ textDecoration: "none", color: "gray" }}>
+                <Link to="/signup" style={{ textDecoration: "none", color: "gray" }}>
                   계정이 없나요? 회원가입으로 이동
                 </Link>
               </Grid>

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,0 +1,20 @@
+import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import { TLoginForm } from "../../model/index";
+
+interface ILoginResponse {
+  success: boolean;
+  error?: string;
+}
+
+export async function login({ email, password }: TLoginForm): Promise<ILoginResponse> {
+  try {
+    const auth = getAuth();
+    await signInWithEmailAndPassword(auth, email, password);
+    return { success: true };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,0 +1,4 @@
+export type TLoginForm = {
+  email: string;
+  password: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES6",
     "module": "ESNext",
     "strict": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -13,7 +13,7 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/": ["./src/"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
로그인 페이지 리팩 1) ts 적용 및 api 분리

## #️⃣연관된 이슈

> #16 

## 📝작업 내용

> 1. LoginPage.jsx -> LoginPage.tsx 파일 변환 (추후 ts로 모두 변경할 예정)
> 2. 로그인 페이지에 있는 api 관련 함수 분리 (api/auth/index.ts에 분리)
> 3. Type형태는 model/index.ts 폴더 생성 후 타입 개별 관리
```
export type TLoginForm = {
  email: string;
  password: string;
};
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
