### PR TITLE
♻️Refactor: 로그인 페이지 react-hook-form 적용

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 120,
+  "printWidth": 90,
 
   "tabWidth": 2,
 

--- a/src/Page/LoginPage.tsx
+++ b/src/Page/LoginPage.tsx
@@ -1,4 +1,12 @@
-import { Alert, Avatar, Box, Container, Grid, TextField, Typography } from "@mui/material";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Container,
+  Grid,
+  TextField,
+  Typography,
+} from "@mui/material";
 import LoginIcon from "@mui/icons-material/Login";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { useCallback, useEffect, useState } from "react";
@@ -6,39 +14,58 @@ import { Link } from "react-router-dom";
 import { Divider } from "antd";
 import { login } from "../api/auth/index";
 import { TLoginForm } from "../model";
+import { useForm } from "react-hook-form";
 
 function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
-  const handleLogin = useCallback(async (loginForm: TLoginForm) => {
-    // 화살표 함수 앞의 괄호를 수정
-    setLoading(true);
-    const response = await login(loginForm);
-    if (!response.success) {
-      setError(response.error || "로그인 실패");
-    }
-    setLoading(false);
-  }, []);
+  // react-hook-form 설정
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TLoginForm>();
 
-  const handleSubmit = useCallback(
-    (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      const form = event.currentTarget;
-
-      const loginForm = {
-        email: form.email.value,
-        password: form.password.value,
-      };
-
-      if (!loginForm.email || !loginForm.password) {
-        setError("모든 항목을 입력해주세요");
-        return;
-      }
-      login(loginForm);
+  // 폼 검증 규칙
+  const validationRules = {
+    email: {
+      required: "이메일을 입력해주세요",
+      pattern: {
+        value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+        message: "올바른 이메일 형식이 아닙니다",
+      },
     },
-    [login],
-  );
+    password: {
+      required: "비밀번호를 입력해주세요",
+      minLength: {
+        value: 6,
+        message: "비밀번호는 최소 6자 이상이어야 합니다",
+      },
+    },
+  };
+
+  // 변수명을 바꾼 이유는 react-hook-form 기능에 handleSubmit라는 이름이 있어 onSubmit으로 변경
+  // useCallback을 쓰지않은 이유 단지 로그인 버튼인데 리렌더링에 최적화된 callback을 사용할 이유가 분명하지 않음
+  const onSubmit = async (formData: TLoginForm) => {
+    try {
+      setLoading(true);
+      const response = await login(formData);
+      if (!response.success) {
+        let errorMessage = "로그인 실패";
+        if (response.error?.includes("wrong-password")) {
+          errorMessage = "비밀번호가 올바르지 않습니다";
+        } else if (response.error?.includes("user-not-found")) {
+          errorMessage = "등록되지 않은 이메일입니다";
+        }
+        setError(errorMessage);
+      }
+    } catch (error) {
+      setError("로그인 중 오류가 발생했습니다");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!error) return;
@@ -51,16 +78,42 @@ function LoginPage() {
     <div className="flex justify-center items-center h-screen">
       <Container component="main" maxWidth="xs">
         <Box className="flex flex-col justify-center items-center">
-          <Avatar sx={{ m: 1, bgcolor: "black" }}>
+          <Avatar
+            sx={{
+              m: 1,
+              bgcolor: "black",
+            }}>
             <LoginIcon />
           </Avatar>
           <Typography component="h1" variant="h5" color="black">
             로그인
           </Typography>
-          <Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 1 }}>
+          <Box
+            component="form"
+            noValidate
+            onSubmit={handleSubmit(onSubmit)}
+            sx={{ mt: 1 }}>
             {/* 관리자 직원에 따라 추가정보 요구 */}
-            <TextField margin="normal" required fullWidth label="이메일" name="email" autoComplete="off" />
-            <TextField margin="normal" required fullWidth label="비밀번호" name="password" type="password" />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              label="이메일"
+              autoComplete="off"
+              {...register("email", validationRules.email)}
+              error={!!errors.email}
+              helperText={errors.email?.message}
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              label="비밀번호"
+              type="password"
+              {...register("password", validationRules.password)}
+              error={!!errors.password}
+              helperText={errors.password?.message}
+            />
             {/* 에러시 오류 표시 */}
             {error ? (
               <Alert sx={{ mt: 3 }} severity="error">
@@ -79,7 +132,12 @@ function LoginPage() {
             </LoadingButton>
             <Grid container justifyContent="flex-end">
               <Grid item>
-                <Link to="/signup" style={{ textDecoration: "none", color: "gray" }}>
+                <Link
+                  to="/signup"
+                  style={{
+                    textDecoration: "none",
+                    color: "gray",
+                  }}>
                   계정이 없나요? 회원가입으로 이동
                 </Link>
               </Grid>

--- a/src/Page/SignupPage.jsx
+++ b/src/Page/SignupPage.jsx
@@ -47,11 +47,11 @@ function SignupPage() {
     }, 3000);
   }, [error]);
 
-  const handlePositionChange = (e) => {
+  const handlePositionChange = e => {
     setPosition(e.target.value);
   };
 
-  const checkCompanyCode = async (code) => {
+  const checkCompanyCode = async code => {
     const database = getDatabase();
     const idRef = ref(database, "companyCode/" + code);
     const snapshot = await get(idRef);
@@ -74,7 +74,7 @@ function SignupPage() {
         const { user } = await createUserWithEmailAndPassword(
           auth,
           email,
-          password
+          password,
         );
         await updateProfile(user, {
           displayName: name,
@@ -102,11 +102,11 @@ function SignupPage() {
         setLoading(false);
       }
     },
-    [dispatch, position, navigate]
+    [dispatch, position, navigate],
   );
 
   const handleSubmit = useCallback(
-    async (e) => {
+    async e => {
       e.preventDefault();
       const data = new FormData(e.currentTarget);
       const name = data.get("name");
@@ -150,13 +150,13 @@ function SignupPage() {
 
       sendUserInfo(name, email, password, companyCode, phoneNumber);
     },
-    [sendUserInfo, position, isManagerCheck, isCodeValid, companyCode]
+    [sendUserInfo, position, isManagerCheck, isCodeValid, companyCode],
   );
 
   useEffect(() => {
     if (window.innerWidth <= 600 && isManagerCheck) {
       alert(
-        "관리자는 PC 전용 서비스 입니다. PC버전으로 회원가입을 진행하셔야 추후에 문제가 발생하지 않습니다. PC로 회원가입 진행 부탁드립니다."
+        "관리자는 PC 전용 서비스 입니다. PC버전으로 회원가입을 진행하셔야 추후에 문제가 발생하지 않습니다. PC로 회원가입 진행 부탁드립니다.",
       );
     }
   }, [isManagerCheck]);
@@ -212,7 +212,7 @@ function SignupPage() {
                   control={
                     <Checkbox
                       checked={isManagerCheck}
-                      onChange={(e) => setManagerCheck(e.target.checked)}
+                      onChange={e => setManagerCheck(e.target.checked)}
                     />
                   }
                 />
@@ -238,7 +238,7 @@ function SignupPage() {
                       sx={{ border: error && "1px solid red" }}
                       disabled={isCodeValid}
                       value={companyCode}
-                      onChange={(e) => setCompanyCode(e.target.value)}
+                      onChange={e => setCompanyCode(e.target.value)}
                     />
                   ) : (
                     <TextField


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> shadcn은 일단 보류 (썡 리액트 프로젝트에서는 적용하는데 편리하지 않음)

> react-hook-form 적용

변수명을 바꾼 이유는 react-hook-form 기능에 handleSubmit라는 이름이 있어 onSubmit으로 변경
useCallback을 쓰지않은 이유 단지 로그인 버튼인데 리렌더링에 최적화된 callback을 사용할 이유가 분명하지 않음

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
