### PR TITLE
[#56] zustand + shadcn 다크모드 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ const App = () => {
 
   return (
     <>
-      <ThemeProvider>
+      <ThemeProvider excludePaths={["/signin", "/signup"]}>
         <ToastContainer position="bottom-right" theme="light" pauseOnHover autoClose={1500} />
         <GuideFab />
         <Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,16 +13,14 @@ import { getAuth, onAuthStateChanged } from "firebase/auth";
 import "./firebase";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { toggleMode } from "./store/darkmodeSlice";
 import GuideFab from "./components/GuideFab";
 import Loading from "./components/common/Loading";
 import { getUser } from "./api";
 import { useUserStore } from "./store/user.store";
-import { useDispatch } from "react-redux";
 import { useShallow } from "zustand/shallow";
+import ThemeProvider from "./components/provider/ThemeProvider";
 
 const App = () => {
-  const dispatch = useDispatch();
   const { currentUser, isLoading, setUser, clearUser } = useUserStore(
     useShallow(state => ({
       currentUser: state?.currentUser,
@@ -50,43 +48,34 @@ const App = () => {
     return () => unsubscribe();
   }, [setUser, clearUser]);
 
-  useEffect(() => {
-    const savedMode = window.localStorage.getItem("darkMode");
-    const body = document.body;
-    if (savedMode === "true") {
-      body.classList.add("dark");
-      dispatch(toggleMode());
-    } else {
-      body.classList.remove("dark");
-    }
-  }, [dispatch]);
-
   if (isLoading) {
     return <Loading />;
   }
 
   return (
     <>
-      <ToastContainer position="bottom-right" theme="light" pauseOnHover autoClose={1500} />
-      <GuideFab />
-      <Routes>
-        <Route path="/" element={<IndexPage />} />
-        <Route path="/:id/*" element={<MainPage />} />
-        <Route path="/signup" element={<SignupPage />} />
-        <Route path="/managerfirst" element={<ManagerFirstPage />} />
-        <Route path="/employeefirst" element={<EmployeeFirstPage />} />
-        <Route
-          path="/signin"
-          element={
-            currentUser ? (
-              <Navigate to={`/${currentUser?.companyCode}/companymain`} />
-            ) : (
-              <LoginPage />
-            )
-          }
-        />
-        <Route path="/*" element={<Notfound />} />
-      </Routes>
+      <ThemeProvider>
+        <ToastContainer position="bottom-right" theme="light" pauseOnHover autoClose={1500} />
+        <GuideFab />
+        <Routes>
+          <Route path="/" element={<IndexPage />} />
+          <Route path="/:id/*" element={<MainPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/managerfirst" element={<ManagerFirstPage />} />
+          <Route path="/employeefirst" element={<EmployeeFirstPage />} />
+          <Route
+            path="/signin"
+            element={
+              currentUser ? (
+                <Navigate to={`/${currentUser?.companyCode}/companymain`} />
+              ) : (
+                <LoginPage />
+              )
+            }
+          />
+          <Route path="/*" element={<Notfound />} />
+        </Routes>
+      </ThemeProvider>
     </>
   );
 };

--- a/src/Components/MainContent.tsx
+++ b/src/Components/MainContent.tsx
@@ -13,7 +13,7 @@ import useDarkMode from "@/store/darkmode.store";
 
 export default function MainContent() {
   const navigate = useNavigate();
-  const { darkMode } = useDarkMode();
+  const darkMode = useDarkMode(state => state.darkMode);
   // const companyName = useCompanyStore(state => state.currentCompany?.companyName);
   // const companyLogo = useCompanyStore(state => state.currentCompany?.companyLogo);
   // currentUser 없을때 조건 부 설정하기 (다른 파일도)

--- a/src/Components/MainContent.tsx
+++ b/src/Components/MainContent.tsx
@@ -9,12 +9,13 @@ import { useShallow } from "zustand/shallow";
 import { useCompanyStore } from "@/store/company.store";
 import { stat } from "fs";
 import CompanyInfoHeader from "./employee/CompanyInfoHeader";
+import useDarkMode from "@/store/darkmode.store";
 
 export default function MainContent() {
   const navigate = useNavigate();
-  const { darkMode } = useSelector(state => state.darkmodeSlice);
-  const companyName = useCompanyStore(state => state.currentCompany?.companyName);
-  const companyLogo = useCompanyStore(state => state.currentCompany?.companyLogo);
+  const { darkMode } = useDarkMode();
+  // const companyName = useCompanyStore(state => state.currentCompany?.companyName);
+  // const companyLogo = useCompanyStore(state => state.currentCompany?.companyLogo);
   // currentUser 없을때 조건 부 설정하기 (다른 파일도)
   const { companyCode, name, jobName, salaryType, userType } = useUserStore(
     useShallow(state => ({
@@ -35,9 +36,7 @@ export default function MainContent() {
       return (
         <div
           data-tour="step-1"
-          className={`flex justify-center items-center h-[calc(100vh_-_18rem)] ${
-            darkMode ? "border-b border-white/50" : "border-b border-black/50"
-          }`}
+          className="flex justify-center items-center h-[calc(100vh_-_18rem)] bg-white-bg dark:bg-dark-bg text-white-text dark:text-dark-text border-b border-white-border dark:border-dark-border"
         >
           <div className="relative flex items-center h-full w-full">
             <div className="flex flex-col items-center justify-center gap-7 cursor-pointer absolute left-[30%] top-[10%]">

--- a/src/Components/provider/ThemeProvider.tsx
+++ b/src/Components/provider/ThemeProvider.tsx
@@ -8,7 +8,9 @@ interface ThemeProviderProps extends PropsWithChildren {
 }
 
 export default function ThemeProvider({ children, excludePaths = [] }: ThemeProviderProps) {
-  const { darkMode, initializeMode } = useDarkMode();
+  const darkMode = useDarkMode(state => state.darkMode);
+  const toggleMode = useDarkMode(state => state.toggleMode);
+  const initializeMode = useDarkMode(state => state.initializeMode);
   const location = useLocation();
 
   const isExcluded = excludePaths.some((path: string) => location.pathname === path);

--- a/src/Components/provider/ThemeProvider.tsx
+++ b/src/Components/provider/ThemeProvider.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren, useEffect } from "react";
+import useDarkMode from "@/store/darkmode.store";
+
+export default function ThemeProvider({ children }: PropsWithChildren) {
+  const { darkMode, initializeMode } = useDarkMode();
+
+  useEffect(() => {
+    initializeMode();
+
+    if (darkMode) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [darkMode, initializeMode]);
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+      {children}
+    </div>
+  );
+}

--- a/src/Components/provider/ThemeProvider.tsx
+++ b/src/Components/provider/ThemeProvider.tsx
@@ -1,21 +1,38 @@
 import { PropsWithChildren, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import useDarkMode from "@/store/darkmode.store";
 
-export default function ThemeProvider({ children }: PropsWithChildren) {
+// ThemeProvider의 props 타입 정의
+interface ThemeProviderProps extends PropsWithChildren {
+  excludePaths: string[];
+}
+
+export default function ThemeProvider({ children, excludePaths = [] }: ThemeProviderProps) {
   const { darkMode, initializeMode } = useDarkMode();
+  const location = useLocation();
+
+  const isExcluded = excludePaths.some((path: string) => location.pathname === path);
 
   useEffect(() => {
-    initializeMode();
+    if (!isExcluded) {
+      initializeMode();
+    }
+  }, [initializeMode, isExcluded]);
 
-    if (darkMode) {
-      document.documentElement.classList.add("dark");
+  useEffect(() => {
+    if (!isExcluded) {
+      document.documentElement.classList.toggle("dark", darkMode);
     } else {
       document.documentElement.classList.remove("dark");
     }
-  }, [darkMode, initializeMode]);
+  }, [darkMode, isExcluded]);
+
+  if (isExcluded) {
+    return <>{children}</>;
+  }
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white">
+    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-200">
       {children}
     </div>
   );

--- a/src/Components/provider/ThemeProvider.tsx
+++ b/src/Components/provider/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import useDarkMode from "@/store/darkmode.store";
+import { useShallow } from "zustand/shallow";
 
 // ThemeProvider의 props 타입 정의
 interface ThemeProviderProps extends PropsWithChildren {
@@ -8,9 +9,13 @@ interface ThemeProviderProps extends PropsWithChildren {
 }
 
 export default function ThemeProvider({ children, excludePaths = [] }: ThemeProviderProps) {
-  const darkMode = useDarkMode(state => state.darkMode);
-  const toggleMode = useDarkMode(state => state.toggleMode);
-  const initializeMode = useDarkMode(state => state.initializeMode);
+  const { darkMode, toggleMode, initializeMode } = useDarkMode(
+    useShallow(state => ({
+      darkMode: state.darkMode,
+      toggleMode: state.toggleMode,
+      initializeMode: state.initializeMode,
+    })),
+  );
   const location = useLocation();
 
   const isExcluded = excludePaths.some((path: string) => location.pathname === path);

--- a/src/store/darkmode.store.ts
+++ b/src/store/darkmode.store.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { createContext, useContext, useEffect } from "react";
 
 interface DarkModeStore {
   darkMode: boolean;

--- a/src/store/darkmode.store.ts
+++ b/src/store/darkmode.store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createContext, useContext, useEffect } from "react";
 
 interface DarkModeStore {
   darkMode: boolean;
@@ -8,7 +9,10 @@ interface DarkModeStore {
 
 const getInitialMode = (): boolean => {
   const savedMode = localStorage.getItem("darkMode");
-  return savedMode ? JSON.parse(savedMode) : false;
+  if (!savedMode) {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  }
+  return JSON.parse(savedMode);
 };
 
 const useDarkMode = create<DarkModeStore>(set => ({
@@ -18,11 +22,13 @@ const useDarkMode = create<DarkModeStore>(set => ({
     set(state => {
       const newMode = !state.darkMode;
       localStorage.setItem("darkMode", JSON.stringify(newMode));
+      document.documentElement.setAttribute("data-theme", newMode ? "dark" : "light");
       return { darkMode: newMode };
     }),
 
   initializeMode: () => {
     const savedMode = getInitialMode();
+    document.documentElement.setAttribute("data-theme", savedMode ? "dark" : "light");
     set({ darkMode: savedMode });
   },
 }));

--- a/src/store/darkmode.store.ts
+++ b/src/store/darkmode.store.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+interface DarkModeStore {
+  darkMode: boolean;
+  toggleMode: () => void;
+  initializeMode: () => void;
+}
+
+const getInitialMode = (): boolean => {
+  const savedMode = localStorage.getItem("darkMode");
+  return savedMode ? JSON.parse(savedMode) : false;
+};
+
+const useDarkMode = create<DarkModeStore>(set => ({
+  darkMode: getInitialMode(),
+
+  toggleMode: () =>
+    set(state => {
+      const newMode = !state.darkMode;
+      localStorage.setItem("darkMode", JSON.stringify(newMode));
+      return { darkMode: newMode };
+    }),
+
+  initializeMode: () => {
+    const savedMode = getInitialMode();
+    set({ darkMode: savedMode });
+  },
+}));
+
+export default useDarkMode;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,6 +84,7 @@ export default {
     },
   },
   darkMode: "class",
+  // eslint-disable-next-line no-undef
   plugins: [require("tailwindcss-animate")],
   important: true,
   mode: "jit",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,7 +83,7 @@ export default {
       },
     },
   },
-  darkMode: ["class", "class"],
+  darkMode: "class",
   plugins: [require("tailwindcss-animate")],
   important: true,
   mode: "jit",


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56 

## 📝작업 내용

> 기존 다크모드 관리를 Redux에서 Zustand로 변경

- 모드 저장 기능 추가 (유저가 로그아웃 후, 재로그인 시 마지막으로 설정된 모드로 나오는 기능)

```tsx
import { create } from "zustand";

interface DarkModeStore {
  darkMode: boolean;
  toggleMode: () => void;
  initializeMode: () => void;
}

const getInitialMode = (): boolean => {
  const savedMode = localStorage.getItem("darkMode");
  if (!savedMode) {
    return window.matchMedia("(prefers-color-scheme: dark)").matches;
  }
  return JSON.parse(savedMode);
};

const useDarkMode = create<DarkModeStore>(set => ({
  darkMode: getInitialMode(),

  toggleMode: () =>
    set(state => {
      const newMode = !state.darkMode;
      localStorage.setItem("darkMode", JSON.stringify(newMode));
      document.documentElement.setAttribute("data-theme", newMode ? "dark" : "light");
      return { darkMode: newMode };
    }),

  initializeMode: () => {
    const savedMode = getInitialMode();
    document.documentElement.setAttribute("data-theme", savedMode ? "dark" : "light");
    set({ darkMode: savedMode });
  },
}));

export default useDarkMode;
```

> shadcn 다크모드 적용

- src/providers/ThemeProvider.tsx 생성

```tsx
import { PropsWithChildren, useEffect } from "react";
import { useLocation } from "react-router-dom";
import useDarkMode from "@/store/darkmode.store";

// ThemeProvider의 props 타입 정의
interface ThemeProviderProps extends PropsWithChildren {
  excludePaths: string[];
}

export default function ThemeProvider({ children, excludePaths = [] }: ThemeProviderProps) {
  const { darkMode, initializeMode } = useDarkMode();
  const location = useLocation();

  const isExcluded = excludePaths.some((path: string) => location.pathname === path);

  useEffect(() => {
    if (!isExcluded) {
      initializeMode();
    }
  }, [initializeMode, isExcluded]);

  useEffect(() => {
    if (!isExcluded) {
      document.documentElement.classList.toggle("dark", darkMode);
    } else {
      document.documentElement.classList.remove("dark");
    }
  }, [darkMode, isExcluded]);

  if (isExcluded) {
    return <>{children}</>;
  }

  return (
    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-200">
      {children}
    </div>
  );
}
```

> 로그인/회원가입 페이지 테마 적용 X

- 애초에 로그인과 회원가입 페이지에는 모드를 변경하는 토글이 없어서 기본 스타일 유지를 위해 전역으로 적용된 ThemeProvider 컴포넌트를 해당 페이지는 제외

```tsx
// ThemeProvider.tsx

export default function ThemeProvider({ children, excludePaths = [] }: ThemeProviderProps) {
  const { darkMode, initializeMode } = useDarkMode();
  const location = useLocation();

  const isExcluded = excludePaths.some((path: string) => location.pathname === path);
```

```tsx
// App.jsx

return (
    <>
      <ThemeProvider excludePaths={["/signin", "/signup"]}>
        <ToastContainer position="bottom-right" theme="light" pauseOnHover autoClose={1500} />
        <GuideFab />
        <Routes>
          <Route path="/" element={<IndexPage />} />
          <Route path="/:id/*" element={<MainPage />} />
          <Route path="/signup" element={<SignupPage />} />
          <Route path="/managerfirst" element={<ManagerFirstPage />} />
          <Route path="/employeefirst" element={<EmployeeFirstPage />} />
          <Route
            path="/signin"
            element={
              currentUser ? (
                <Navigate to={`/${currentUser?.companyCode}/companymain`} />
              ) : (
                <LoginPage />
              )
            }
          />
          <Route path="/*" element={<Notfound />} />
        </Routes>
      </ThemeProvider>
    </>
  );
};
```

![스크린샷 2025-02-18 오후 7 21 27](https://github.com/user-attachments/assets/4588049a-7e46-4031-a4e6-ed6d913cf642)

![스크린샷 2025-02-18 오후 7 21 41](https://github.com/user-attachments/assets/bf3eced5-bdac-45a5-bd83-8a9b5f39fd2e)


## 💬리뷰 요구사항(선택)

> 관리자 로그인 기준으로 했을 때, 메인 페이지의 배경화면의 색깔이 변경이 안될 때가 있음. 아마 기존 컴포넌트들의 MUI라이브러리나 자세한 설정이 되있지 않아서 렌더링이 느린것으로 보임. 새로고침하고 다시 토글을 눌러보면 정상적으로 작동함.

> 추후 다른 컴포넌트들은 MUI를 모두 제거하고 shadcn 라이브러리를 추가할 예정이라 다크모드 세팅 파일 또한 수정될 것으로 보임
